### PR TITLE
CORE: vmm_schedalgo_prr: Use list_del_init() instead of list_del()

### DIFF
--- a/core/schedalgo/vmm_schedalgo_prr.c
+++ b/core/schedalgo/vmm_schedalgo_prr.c
@@ -138,7 +138,7 @@ int vmm_schedalgo_rq_dequeue(void *rq,
 	p = p - 1;
 	rq_entry = list_first_entry(&rqi->list[p],
 				struct vmm_schedalgo_rq_entry, head);
-	list_del(&rq_entry->head);
+	list_del_init(&rq_entry->head);
 
 	if (next) {
 		*next = rq_entry->vcpu;
@@ -164,7 +164,7 @@ int vmm_schedalgo_rq_detach(void *rq, struct vmm_vcpu *vcpu)
 		return VMM_EFAIL;
 	}
 
-	list_del(&rq_entry->head);
+	list_del_init(&rq_entry->head);
 
 	return VMM_OK;
 }


### PR DESCRIPTION
In a very rare situation, the vmm_scheduler_state_change() can call
vmm_schedalgo_rq_detach() for already detatched VCPU which in-turn
causes crash in list_del() used by vmm_schedalgo_rq_detach() of
priority round-robin scheduling algorithm.

This can happen when a VCPU is just dequeued by __vmm_scheduler_next2()
on Host CPU A and on other Host CPU B someone tries to PAUSE the same
VCPU.

This patch tries to fix above issue by using list_del_init() instead
of list_del() in priority round-robin scheduling algorithm.

Signed-off-by: Anup Patel <anup@brainfault.org>