### PR TITLE
RISC-V: Allow multiple version of riscv gcc to build xvisor

### DIFF
--- a/arch/riscv/cpu/generic/objects.mk
+++ b/arch/riscv/cpu/generic/objects.mk
@@ -29,12 +29,12 @@
 ifeq ($(CONFIG_64BIT),y)
 arch-cflags-y += -mabi=lp64
 march-y = rv64im
-cpu-mergeflags += -melf64lriscv_lp64
+cpu-mergeflags += -melf64lriscv
 else
 arch-ldflags-y += -static-libgcc -lgcc
 arch-cflags-y += -mabi=ilp32
 march-y = rv32im
-cpu-mergeflags += -melf32lriscv_ilp32
+cpu-mergeflags += -melf32lriscv
 endif
 
 ifeq ($(CONFIG_RISCV_ISA_A),y)


### PR DESCRIPTION
The -melf64lriscv_lp64 and -melf32lriscv_ilp32 options are understood by
gcc version 9 but not by gcc version 7 or 8.

By default Ubuntu bionic (on travis) uses version 7 and the build is
failing.

So we change the 2 linker options to the more generic -melf64lriscv and
-melf32lriscv to get xvisor to build on Ubuntu bionic (travis).

Signed-off-by: Jean-Christophe Dubois <jcd@tribudubois.net>
Reviewed-by: Anup Patel <anup@brainfault.org>