### PR TITLE
TOOLS: d2c.py: Add varalign and varprefix parameters

### DIFF
--- a/tools/rules.mk
+++ b/tools/rules.mk
@@ -56,7 +56,7 @@ $(build_dir)/%.dep: $(src_dir)/%.data
 $(build_dir)/%.c: $(src_dir)/%.data
 	$(V)mkdir -p `dirname $@`
 	$(if $(V), @echo " (d2c)       $(subst $(build_dir)/,,$@)")
-	$(V)$(src_dir)/tools/scripts/d2c.py $(subst $(src_dir)/,,$<) > $@
+	$(V)$(src_dir)/tools/scripts/d2c.py $< 16 $(shell echo $(subst .c,,$(subst $(build_dir)/,,$@)) | sed -e 's/[\. -\/]/_/g')_data > $@
 
 $(build_dir)/%.dep: $(build_dir)/%.data
 	$(V)mkdir -p `dirname $@`
@@ -67,7 +67,7 @@ $(build_dir)/%.dep: $(build_dir)/%.data
 $(build_dir)/%.c: $(build_dir)/%.data
 	$(V)mkdir -p `dirname $@`
 	$(if $(V), @echo " (d2c)       $(subst $(build_dir)/,,$@)")
-	$(V)(cd $(build_dir) && $(src_dir)/tools/scripts/d2c.py $(subst $(build_dir)/,,$<) > $@ && cd $(src_dir))
+	$(V)$(src_dir)/tools/scripts/d2c.py $< 16 $(shell echo $(subst .c,,$(subst $(build_dir)/,,$@)) | sed -e 's/[\. -\/]/_/g')_data > $@
 
 ifdef CONFIG_CPATCH
 

--- a/tools/scripts/d2c.py
+++ b/tools/scripts/d2c.py
@@ -21,12 +21,12 @@
 # @author Anup Patel (anup@brainfault.org)
 # @brief Create C source file from binary data file
 #
-# The purpose here is to take a binary file and output it
-# as an array of bytes suitable for compiling and linking
-# with a C/C++ program.
+# The purpose here is to take a binary file and output it as an array
+# of bytes suitable for compiling and linking with a C/C++ program.
 #
-# Example usage: ./2c.py somefile.data > somefile.c
+# Example usage: ./d2c.py somefile 8 some > somefile.c
 # */
+
 
 import sys
 import re
@@ -35,17 +35,30 @@ if __name__ == "__main__":
 	try:
 		filename = sys.argv[1]
 	except IndexError:
-		print("Usage: %s <filename>" % sys.argv[0])
+		print("Input file not available")
+		print("Usage: %s <filename> <varalign> <varprefix>" % sys.argv[0])
 		raise SystemExit
 
 	contentFile = open(filename, "rb");
-	varname = filename;
 
-	varname = re.sub('[. -/]', '_', varname);
+	try:
+		varalign = sys.argv[2]
+	except IndexError:
+		print("Output C source variable alignment not available")
+		print("Usage: %s <filename> <varalign> <varprefix>" % sys.argv[0])
+		raise SystemExit
+
+	try:
+		varname = sys.argv[3]
+	except IndexError:
+		print("Output C source variable name not available")
+		print("Usage: %s <filename> <varalign> <varprefix>" % sys.argv[0])
+		raise SystemExit
+
 	varszname = varname + "_size";
 	varname = varname + "_start";
 
-	print("const char %s[] = {" % varname)
+	print("const char __attribute__((aligned(%s))) %s[] = {" % (varalign, varname))
 
 	filesize = 0;
 	while True:


### PR DESCRIPTION
This patch extends d2c.py to have two new parameters:
1. varalign: C array alignment
2. varprefix: C array name prefix

These new parameters help us make d2c.py more generic
which allows it to be used for other file types as well.

Signed-off-by: Anup Patel <anup@brainfault.org>